### PR TITLE
Changes upper version limit on logstash-core

### DIFF
--- a/logstash-filter-kubernetes.gemspec
+++ b/logstash-filter-kubernetes.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-kubernetes'
-  s.version         = '0.2.1'
+  s.version         = '0.2.2'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This filter extracts useful kubernetes information from kubelet logfile symlinks."
   s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
+  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 6.0.0"
   s.add_development_dependency 'logstash-devutils', '~> 0'
 end


### PR DESCRIPTION
This PR removes upper boundary on logstash-core to make it work with logstash 5.x.